### PR TITLE
Convert tests to xunit

### DIFF
--- a/src/StringSearch.Legacy/SearchString.cs
+++ b/src/StringSearch.Legacy/SearchString.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PiSearch
  * SearchString - static class containing methods to search through a given string (or other data type)
  *  for some string (or other data type) to be found.
@@ -16,7 +16,7 @@ namespace StringSearch.Legacy
 {
     public static class SearchString
     {
-        public static int[] Search(string toSearch, string lookFor)
+        public static long[] Search(string toSearch, string lookFor)
         {
             //Validation
             if(toSearch == null)
@@ -37,7 +37,7 @@ namespace StringSearch.Legacy
             //The string to be searched must be longer than or of equal length to the string being searched for
             if(toSearch.Length >= lookFor.Length)
             {
-                List<int> foundIdxs = new List<int>();
+                List<long> foundIdxs = new List<long>();
 
                 LinkedList<char> prevChars = new LinkedList<char>();
 
@@ -82,7 +82,7 @@ namespace StringSearch.Legacy
             }
             else //Otherwise the string being seacrhed is shorter than the string being searched for, there cannot be any matches
             {
-                return new int[0];
+                return Array.Empty<long>();
             }
         }
 

--- a/src/StringSearchConsole/Program.cs
+++ b/src/StringSearchConsole/Program.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Program entry point for the String Search Console application, the development interface for the PiSearch project
  * By Josh Keegan 07/11/2014
  */
@@ -754,7 +754,7 @@ namespace StringSearchConsole
                 stopwatch.Reset();
                 stopwatch.Start();
 
-                int[] foundIdxs = SearchString.Search(loadedString, toFind);
+                long[] foundIdxs = SearchString.Search(loadedString, toFind);
                 Console.WriteLine("Found {0} results", foundIdxs.Length);
                 foreach(int idx in foundIdxs)
                 {

--- a/test/UnitTests/Api/AutoMapperTests.cs
+++ b/test/UnitTests/Api/AutoMapperTests.cs
@@ -1,17 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System;
 using AutoMapper;
 using Microsoft.Extensions.DependencyInjection;
-using NUnit.Framework;
 using StringSearch.Api.Di;
+using Xunit;
 
 namespace UnitTests.Api
 {
-    [TestFixture]
     public class AutoMapperTests
     {
-        [Test]
+        [Fact]
         public void ConfigurationIsValid()
         {
             IServiceCollection services = new ServiceCollection();

--- a/test/UnitTests/Api/Extensions/HttpRequestExtensionsTests.cs
+++ b/test/UnitTests/Api/Extensions/HttpRequestExtensionsTests.cs
@@ -1,20 +1,19 @@
 using System.Net;
 using Microsoft.AspNetCore.Http;
 using NSubstitute;
-using NUnit.Framework;
 using StringSearch.Api.Extensions;
+using Xunit;
 
 namespace UnitTests.Api.Extensions
 {
-    [TestFixture]
     public class HttpRequestExtensionsTests
     {
         [Theory]
-        [TestCase("119.140.0.200")]
-        [TestCase("127.0.0.1")]
-        [TestCase("192.168.0.1")]
-        [TestCase("::1")]
-        [TestCase("2001:0db8:85a3:0000:0000:8a2e:0370:7334")]
+        [InlineData("119.140.0.200")]
+        [InlineData("127.0.0.1")]
+        [InlineData("192.168.0.1")]
+        [InlineData("::1")]
+        [InlineData("2001:0db8:85a3:0000:0000:8a2e:0370:7334")]
         public void GetClientIp_ForwardedForSingle_ReturnsForwardedFor(string strIp)
         {
             // Arrange
@@ -30,15 +29,15 @@ namespace UnitTests.Api.Extensions
             IPAddress actual = request.GetClientIp();
 
             // Assert
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
         [Theory]
-        [TestCase("119.140.0.200")]
-        [TestCase("127.0.0.1")]
-        [TestCase("192.168.0.1")]
-        [TestCase("::1")]
-        [TestCase("2001:0db8:85a3:0000:0000:8a2e:0370:7334")]
+        [InlineData("119.140.0.200")]
+        [InlineData("127.0.0.1")]
+        [InlineData("192.168.0.1")]
+        [InlineData("::1")]
+        [InlineData("2001:0db8:85a3:0000:0000:8a2e:0370:7334")]
         public void GetClientIp_NoForwardedFor_ReturnsHttpContextConnectionRemoteIpAddress(string strIp)
         {
             // Arrange
@@ -51,7 +50,7 @@ namespace UnitTests.Api.Extensions
             IPAddress actual = request.GetClientIp();
 
             // Assert
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/test/UnitTests/Legacy/Collections/BigBoolArrayTests.cs
+++ b/test/UnitTests/Legacy/Collections/BigBoolArrayTests.cs
@@ -1,31 +1,30 @@
-﻿using System.IO;
-using NUnit.Framework;
+using System.IO;
 using StringSearch.Legacy.Collections;
+using Xunit;
 
 namespace UnitTests.Legacy.Collections
 {
-    [TestFixture]
     public class BigBoolArrayTests
     {
-        [Test]
+        [Fact]
         public void TestConstructor()
         {
             BigBoolArray a = new BigBoolArray(10);
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithStream()
         {
             BigBoolArray a = new BigBoolArray(10, new MemoryStream(2));
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithStreamTooSmall()
         {
             BigBoolArray a = new BigBoolArray(10, new MemoryStream(1));
         }
 
-        [Test]
+        [Fact]
         public void TestReadWrite()
         {
             BigBoolArray a = new BigBoolArray(50);
@@ -35,13 +34,13 @@ namespace UnitTests.Legacy.Collections
             a[43] = true;
             a[47] = false;
 
-            Assert.AreEqual(false, a[0]);
-            Assert.AreEqual(true, a[1]);
-            Assert.AreEqual(true, a[43]);
-            Assert.AreEqual(false, a[47]);
+            Assert.False(a[0]);
+            Assert.True(a[1]);
+            Assert.True(a[43]);
+            Assert.False(a[47]);
         }
 
-        [Test]
+        [Fact]
         public void TestReadWriteAlternating()
         {
             BigBoolArray a = new BigBoolArray(100);
@@ -53,7 +52,7 @@ namespace UnitTests.Legacy.Collections
 
             for(int i = 0; i < a.Length; i++)
             {
-                Assert.AreEqual(i % 2 == 0, a[i]);
+                Assert.Equal(i % 2 == 0, a[i]);
             }
         }
     }

--- a/test/UnitTests/Legacy/Collections/FixedLengthQueueTests.cs
+++ b/test/UnitTests/Legacy/Collections/FixedLengthQueueTests.cs
@@ -1,58 +1,57 @@
-﻿using System;
-using NUnit.Framework;
+using System;
 using StringSearch.Legacy.Collections;
+using Xunit;
 
 namespace UnitTests.Legacy.Collections
 {
-    [TestFixture]
     public class FixedLengthQueueTests
     {
-        [Test]
+        [Fact]
         public void TestConstructorLength()
         {
             FixedLengthQueue<int> q = new FixedLengthQueue<int>(5);
-            Assert.AreEqual(5, q.Length);
+            Assert.Equal(5, q.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorInitialValues()
         {
             int[] initialValues = new int[] { 4, 7, 3, 11, 215, -4 };
 
             FixedLengthQueue<int> q = new FixedLengthQueue<int>(initialValues);
 
-            Assert.AreEqual(initialValues.Length, q.Length);
+            Assert.Equal(initialValues.Length, q.Length);
 
             for(int i = 0; i < initialValues.Length; i++)
             {
-                Assert.AreEqual(initialValues[i], q[i]);
+                Assert.Equal(initialValues[i], q[i]);
             }
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorInitialValuesAndHead()
         {
             int[] initialValues = new int[] { 4, 7, 3, 11, 215, -4 };
             int head = 3;
             FixedLengthQueue<int> q = new FixedLengthQueue<int>(initialValues, head);
 
-            Assert.AreEqual(initialValues.Length, q.Length);
+            Assert.Equal(initialValues.Length, q.Length);
 
             for (int i = 0; i < initialValues.Length; i++)
             {
                 int j = (i + head) % initialValues.Length;
 
-                Assert.AreEqual(initialValues[j], q[i]);
+                Assert.Equal(initialValues[j], q[i]);
             }
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorNegativeLength()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new FixedLengthQueue<int>(-1));
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorNegativeHead()
         {
             int[] initialValues = new int[] { 4, 7, 3, 11, 215, -4 };
@@ -61,7 +60,7 @@ namespace UnitTests.Legacy.Collections
             Assert.Throws<ArgumentOutOfRangeException>(() => new FixedLengthQueue<int>(initialValues, head));
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorHeadTooBig()
         {
             int[] initialValues = new int[] { 4, 7, 3, 11, 215, -4 };
@@ -70,7 +69,7 @@ namespace UnitTests.Legacy.Collections
             Assert.Throws<ArgumentOutOfRangeException>(() => new FixedLengthQueue<int>(initialValues, head));
         }
 
-        [Test]
+        [Fact]
         public void TestAccessIndexHeadZero()
         {
             int[] initialValues = new int[] { 4, 7, 3, 11, 215, -4 };
@@ -79,22 +78,22 @@ namespace UnitTests.Legacy.Collections
 
             for(int i = 0; i < q.Length; i++)
             {
-                Assert.AreEqual(initialValues[i], q[i]);
+                Assert.Equal(initialValues[i], q[i]);
             }
         }
 
-        [Test]
+        [Fact]
         public void TestAccessIndexArbitraryHead()
         {
             int[] initialValues = new int[] { 4, 7, 3, 11, 215, -4 };
             int head = 3;
             FixedLengthQueue<int> q = new FixedLengthQueue<int>(initialValues, head);
 
-            Assert.AreEqual(initialValues[head], q[0]);
-            Assert.AreEqual(initialValues[0], q[initialValues.Length - head]);
+            Assert.Equal(initialValues[head], q[0]);
+            Assert.Equal(initialValues[0], q[initialValues.Length - head]);
         }
 
-        [Test]
+        [Fact]
         public void TestEnqueue()
         {
             int[] initialValues = new int[] { 4, 7, 3, 11, 215, -4 };
@@ -103,31 +102,31 @@ namespace UnitTests.Legacy.Collections
 
             q.Enqueue(5);
 
-            Assert.AreEqual(5, q[q.Length - 1]);
+            Assert.Equal(5, q[q.Length - 1]);
         }
 
-        [Test]
+        [Fact]
         public void TestEnqueueUnsetValues()
         {
             FixedLengthQueue<int> q = new FixedLengthQueue<int>(12);
 
             q.Enqueue(5);
 
-            Assert.AreEqual(5, q[q.Length - 1]);
+            Assert.Equal(5, q[q.Length - 1]);
         }
 
-        [Test]
+        [Fact]
         public void TestEnqueueDoesntChangeLength()
         {
             int length = 12;
             FixedLengthQueue<int> q = new FixedLengthQueue<int>(length);
 
-            Assert.AreEqual(length, q.Length);
+            Assert.Equal(length, q.Length);
             q.Enqueue(5);
-            Assert.AreEqual(length, q.Length);
+            Assert.Equal(length, q.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestEnqueueDequeue()
         {
             int[] initialValues = new int[] { 4, 7, 3, 11, 215, -4 };
@@ -139,8 +138,8 @@ namespace UnitTests.Legacy.Collections
             int expected = initialValues[head];
             int actual = q.DequeueEnqueue(newVal);
 
-            Assert.AreEqual(expected, actual);
-            Assert.AreEqual(newVal, q[q.Length - 1]);
+            Assert.Equal(expected, actual);
+            Assert.Equal(newVal, q[q.Length - 1]);
         }
     }
 }

--- a/test/UnitTests/Legacy/Collections/FourBitDigitBigArrayTests.cs
+++ b/test/UnitTests/Legacy/Collections/FourBitDigitBigArrayTests.cs
@@ -1,16 +1,15 @@
 using System;
 using System.IO;
-using NUnit.Framework;
 using StringSearch.Legacy.Collections;
 using StringSearch.Legacy.IO;
 using UnitTests.TestObjects.Extensions;
+using Xunit;
 
 namespace UnitTests.Legacy.Collections
 {
-    [TestFixture]
     public class FourBitDigitBigArrayTests : ForceGcBetweenTests
     {
-        [Test]
+        [Fact]
         public void TestConstructor()
         {
             const string str = "1234";
@@ -20,27 +19,27 @@ namespace UnitTests.Legacy.Collections
             FourBitDigitBigArray a = new FourBitDigitBigArray(memStream);
         }
 
-        [Test]
+        [Fact]
         public void TestEmpty()
         {
             Stream memStream = "".ToFourBitDigitStream();
 
             FourBitDigitBigArray a = new FourBitDigitBigArray(memStream);
 
-            Assert.AreEqual(0, a.Length);
+            Assert.Equal(0, a.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestOddNumberOfDigits()
         {
             Stream memStream = "123".ToFourBitDigitStream();
 
             FourBitDigitBigArray a = new FourBitDigitBigArray(memStream);
 
-            Assert.AreEqual(3, a.Length);
+            Assert.Equal(3, a.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestGet()
         {
             const string str = "391";
@@ -52,11 +51,11 @@ namespace UnitTests.Legacy.Collections
                 char c = str[i];
                 byte b = a[i];
 
-                Assert.AreEqual(c.ToString(), b.ToString());
+                Assert.Equal(c.ToString(), b.ToString());
             }
         }
 
-        [Test]
+        [Fact]
         public void TestSetEven()
         {
             const string orig = "391";
@@ -64,15 +63,15 @@ namespace UnitTests.Legacy.Collections
             FourBitDigitBigArray a = orig.ToFourBitDigitBigArray();
 
             a[0] = 7;
-            Assert.AreEqual(7, a[0]);
+            Assert.Equal(7, a[0]);
 
             for (int i = 1; i < orig.Length; i++)
             {
-                Assert.AreEqual(orig[i].ToString(), a[i].ToString());
+                Assert.Equal(orig[i].ToString(), a[i].ToString());
             }
         }
 
-        [Test]
+        [Fact]
         public void TestSetOdd()
         {
             const string orig = "391";
@@ -80,18 +79,18 @@ namespace UnitTests.Legacy.Collections
             FourBitDigitBigArray a = orig.ToFourBitDigitBigArray();
 
             a[1] = 7;
-            Assert.AreEqual(7, a[1]);
+            Assert.Equal(7, a[1]);
 
             for (int i = 0; i < orig.Length; i++)
             {
                 if(i != 1)
                 {
-                    Assert.AreEqual(orig[i].ToString(), a[i].ToString());
+                    Assert.Equal(orig[i].ToString(), a[i].ToString());
                 }
             }
         }
 
-        [Test]
+        [Fact]
         public void TestAccessOutOfRangeNeg()
         {
             FourBitDigitBigArray a = "123".ToFourBitDigitBigArray();
@@ -102,7 +101,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestAccessOutOfRange()
         {
             FourBitDigitBigArray a = "123".ToFourBitDigitBigArray();
@@ -113,7 +112,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestSetOutOfRangeNeg()
         {
             FourBitDigitBigArray a = "123".ToFourBitDigitBigArray();
@@ -124,7 +123,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestSetOutOfRange()
         {
             FourBitDigitBigArray a = "123".ToFourBitDigitBigArray();
@@ -135,7 +134,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestSetOverflow()
         {
             FourBitDigitBigArray a = "123".ToFourBitDigitBigArray();
@@ -146,7 +145,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestSetReservedOverflow()
         {
             //Highest possible value in 4 bits (15) reserved for marking that half of the byte as not in use
@@ -159,72 +158,72 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestLength()
         {
             FourBitDigitBigArray a = "123".ToFourBitDigitBigArray();
-            Assert.AreEqual(3, a.Length);
+            Assert.Equal(3, a.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestLengthEven()
         {
             FourBitDigitBigArray a = "1234".ToFourBitDigitBigArray();
-            Assert.AreEqual(4, a.Length);
+            Assert.Equal(4, a.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestLengthEmpty()
         {
             const long length = 3;
             FourBitDigitBigArray a = makeNew(length);
-            Assert.AreEqual(length, a.Length);
+            Assert.Equal(length, a.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestLengthEmptyEven()
         {
             const long length = 4;
             FourBitDigitBigArray a = makeNew(length);
-            Assert.AreEqual(length, a.Length);
+            Assert.Equal(length, a.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestLengthBig()
         {
             const long length = 3000000001;
             FourBitDigitBigArray a = makeNew(length);
-            Assert.AreEqual(length, a.Length);
+            Assert.Equal(length, a.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestLengthBigEven()
         {
             const long length = 3000000000;
             FourBitDigitBigArray a = makeNew(length);
-            Assert.AreEqual(length, a.Length);
+            Assert.Equal(length, a.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorBigMemoryStreamAsUnderlyingStream()
         {
             BigMemoryStream stream = new BigMemoryStream(5);
             FourBitDigitBigArray a = new FourBitDigitBigArray(stream);
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorBigMemoryStreamAsUnderlyingStreamBig()
         {
             BigMemoryStream stream = new BigMemoryStream(3000000000); //3bil bytes ~= 3GB
             FourBitDigitBigArray a = new FourBitDigitBigArray(stream);
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetBig()
         {
             FourBitDigitBigArray a = makeNew(3000000000);
             a[2500000000] = 5;
-            Assert.AreEqual(5, a[2500000000]);
+            Assert.Equal(5, a[2500000000]);
         }
 
         #region Helpers

--- a/test/UnitTests/Legacy/Collections/MemoryEfficientBigULongArrayTests.cs
+++ b/test/UnitTests/Legacy/Collections/MemoryEfficientBigULongArrayTests.cs
@@ -1,91 +1,90 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using NUnit.Framework;
 using StringSearch.Legacy.Collections;
+using Xunit;
 
 namespace UnitTests.Legacy.Collections
 {
-    [TestFixture]
     public class MemoryEfficientBigULongArrayTests : ForceGcBetweenTests
     {
-        [Test]
+        [Fact]
         public void TestConstructor()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10);
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithMaxValue()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, 1000);
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithStream()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, 1000, new MemoryStream());
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithStreamNoMaxValue()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, new MemoryStream());
         }
 
-        [Test]
+        [Fact]
         public void TestLength()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10);
-            Assert.AreEqual(10, arr.Length);
+            Assert.Equal(10, arr.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestMaxValue()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, 1000);
-            Assert.AreEqual(1000, arr.MaxValue);
+            Assert.Equal(1000ul, arr.MaxValue);
         }
 
-        [Test]
+        [Fact]
         public void TestGetUnset()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, 1000);
-            Assert.AreEqual(0, arr[5]);
+            Assert.Equal(0ul, arr[5]);
         }
 
-        [Test]
+        [Fact]
         public void TestGetUnsetWithSpecifiedStream()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, 1000, new MemoryStream());
-            Assert.AreEqual(0, arr[5]);
+            Assert.Equal(0ul, arr[5]);
         }
 
-        [Test]
+        [Fact]
         public void TestGetSet()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, 1000);
             arr[3] = 400;
-            Assert.AreEqual(400, arr[3]);
+            Assert.Equal(400ul, arr[3]);
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetWithSpecifiedStream()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, 1000, new MemoryStream());
             arr[3] = 400;
-            Assert.AreEqual(400, arr[3]);
+            Assert.Equal(400ul, arr[3]);
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetByteAligned()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, byte.MaxValue);
             arr[7] = 12;
-            Assert.AreEqual(12, arr[7]);
+            Assert.Equal(12ul, arr[7]);
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetMultipleValues()
         {
             ulong[] ulongArr = { 23, 47, 1000, 247, 803, 2, 0, 403 };
@@ -100,11 +99,11 @@ namespace UnitTests.Legacy.Collections
             //Check the values
             for(int i = 0; i < ulongArr.Length; i++)
             {
-                Assert.AreEqual(ulongArr[i], arr[i]);
+                Assert.Equal(ulongArr[i], arr[i]);
             }
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetMultipleValuesReverseOrder()
         {
             ulong[] ulongArr = { 23, 47, 1000, 247, 803, 2, 0, 403 };
@@ -119,11 +118,11 @@ namespace UnitTests.Legacy.Collections
             //Check the values
             for (int i = ulongArr.Length - 1; i >= 0; i--)
             {
-                Assert.AreEqual(ulongArr[i], arr[i]);
+                Assert.Equal(ulongArr[i], arr[i]);
             }
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetBigArray()
         {
             long len = 1000000000;
@@ -134,10 +133,10 @@ namespace UnitTests.Legacy.Collections
 
             arr[setPos] = setVal;
 
-            Assert.AreEqual(setVal, arr[setPos]);
+            Assert.Equal(setVal, arr[setPos]);
         }
 
-        [Test]
+        [Fact]
         public void TestGetIndexTooSmall()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, 1000);
@@ -148,7 +147,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestGetIndexTooBig()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, 1000);
@@ -159,7 +158,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestSetIndexTooSmall()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, 1000);
@@ -170,7 +169,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestSetValueTooBig()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, 1000);
@@ -181,7 +180,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestSetIndexTooBig()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, 1000);
@@ -192,14 +191,14 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorBig()
         {
             //number 7 requires minimum 3 bits, so that's (5bil * 3) / 8 bytes ~= 1.75GiB of RAM used
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(5000000000, 7);
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorBiggerThan2Gb()
         {
             //Test that an array larger than 2GiB in size can be constructed
@@ -208,16 +207,16 @@ namespace UnitTests.Legacy.Collections
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(length, byte.MaxValue);
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetBig()
         {
             MemoryEfficientBigULongArray arr = new MemoryEfficientBigULongArray(10, ulong.MaxValue);
             arr[3] = ulong.MaxValue;
-            Assert.AreEqual(ulong.MaxValue, arr[3]);
+            Assert.Equal(ulong.MaxValue, arr[3]);
         }
 
         #region Test Internals
-        [Test]
+        [Fact]
         public void TestCalculateBitsPerValue()
         {
             Dictionary<ulong, byte> answers = new Dictionary<ulong, byte>()
@@ -237,7 +236,7 @@ namespace UnitTests.Legacy.Collections
                 byte numBits = kvp.Value;
 
                 byte actual = MemoryEfficientBigULongArray.CalculateBitsPerValue(num);
-                Assert.AreEqual(numBits, actual);
+                Assert.Equal(numBits, actual);
             }
         }
         #endregion

--- a/test/UnitTests/Legacy/Collections/MemoryEfficientByteAlignedBigULongArrayTests.cs
+++ b/test/UnitTests/Legacy/Collections/MemoryEfficientByteAlignedBigULongArrayTests.cs
@@ -1,91 +1,90 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using NUnit.Framework;
 using StringSearch.Legacy.Collections;
+using Xunit;
 
 namespace UnitTests.Legacy.Collections
 {
-    [TestFixture]
     public class MemoryEfficientByteAlignedBigULongArrayTests : ForceGcBetweenTests
     {
-        [Test]
+        [Fact]
         public void TestConstructor()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10);
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithMaxValue()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, 1000);
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithStream()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, 1000, new MemoryStream());
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithStreamNoMaxValue()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, new MemoryStream());
         }
 
-        [Test]
+        [Fact]
         public void TestLength()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10);
-            Assert.AreEqual(10, arr.Length);
+            Assert.Equal(10, arr.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestMaxValue()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, 1000);
-            Assert.AreEqual(1000, arr.MaxValue);
+            Assert.Equal(1000ul, arr.MaxValue);
         }
 
-        [Test]
+        [Fact]
         public void TestGetUnset()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, 1000);
-            Assert.AreEqual(0, arr[5]);
+            Assert.Equal(0ul, arr[5]);
         }
 
-        [Test]
+        [Fact]
         public void TestGetUnsetWithSpecifiedStream()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, 1000, new MemoryStream());
-            Assert.AreEqual(0, arr[5]);
+            Assert.Equal(0ul, arr[5]);
         }
 
-        [Test]
+        [Fact]
         public void TestGetSet()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, 1000);
             arr[3] = 400;
-            Assert.AreEqual(400, arr[3]);
+            Assert.Equal(400ul, arr[3]);
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetWithSpecifiedStream()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, 1000, new MemoryStream());
             arr[3] = 400;
-            Assert.AreEqual(400, arr[3]);
+            Assert.Equal(400ul, arr[3]);
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetByteAligned()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, byte.MaxValue);
             arr[7] = 12;
-            Assert.AreEqual(12, arr[7]);
+            Assert.Equal(12ul, arr[7]);
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetMultipleValues()
         {
             ulong[] ulongArr = { 23, 47, 1000, 247, 803, 2, 0, 403 };
@@ -100,11 +99,11 @@ namespace UnitTests.Legacy.Collections
             //Check the values
             for (int i = 0; i < ulongArr.Length; i++)
             {
-                Assert.AreEqual(ulongArr[i], arr[i]);
+                Assert.Equal(ulongArr[i], arr[i]);
             }
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetMultipleValuesReverseOrder()
         {
             ulong[] ulongArr = { 23, 47, 1000, 247, 803, 2, 0, 403 };
@@ -119,11 +118,11 @@ namespace UnitTests.Legacy.Collections
             //Check the values
             for (int i = ulongArr.Length - 1; i >= 0; i--)
             {
-                Assert.AreEqual(ulongArr[i], arr[i]);
+                Assert.Equal(ulongArr[i], arr[i]);
             }
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetBigArray()
         {
             long len = 1000000000;
@@ -134,10 +133,10 @@ namespace UnitTests.Legacy.Collections
 
             arr[setPos] = setVal;
 
-            Assert.AreEqual(setVal, arr[setPos]);
+            Assert.Equal(setVal, arr[setPos]);
         }
 
-        [Test]
+        [Fact]
         public void TestGetIndexTooSmall()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, 1000);
@@ -148,7 +147,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestGetIndexTooBig()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, 1000);
@@ -159,7 +158,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestSetIndexTooSmall()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, 1000);
@@ -170,7 +169,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestSetValueTooBig()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, 1000);
@@ -182,7 +181,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestSetIndexTooBig()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, 1000);
@@ -194,7 +193,7 @@ namespace UnitTests.Legacy.Collections
             });
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorBiggerThan2Gb()
         {
             //Test that an array larger than 2GiB in size can be constructed
@@ -203,16 +202,16 @@ namespace UnitTests.Legacy.Collections
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(length, byte.MaxValue);
         }
 
-        [Test]
+        [Fact]
         public void TestGetSetBig()
         {
             MemoryEfficientByteAlignedBigULongArray arr = new MemoryEfficientByteAlignedBigULongArray(10, ulong.MaxValue);
             arr[3] = ulong.MaxValue;
-            Assert.AreEqual(ulong.MaxValue, arr[3]);
+            Assert.Equal(ulong.MaxValue, arr[3]);
         }
 
         #region Test Internals
-        [Test]
+        [Fact]
         public void TestCalculateBytesPerValue()
         {
             Dictionary<ulong, byte> answers = new Dictionary<ulong, byte>()
@@ -232,7 +231,7 @@ namespace UnitTests.Legacy.Collections
                 byte numBits = kvp.Value;
 
                 byte actual = MemoryEfficientByteAlignedBigULongArray.CalculateBytesPerValue(num);
-                Assert.AreEqual(numBits, actual);
+                Assert.Equal(numBits, actual);
             }
         }
         #endregion

--- a/test/UnitTests/Legacy/Collections/MemoryEfficientComplementBigULongArrayTests.cs
+++ b/test/UnitTests/Legacy/Collections/MemoryEfficientComplementBigULongArrayTests.cs
@@ -1,58 +1,57 @@
-﻿using System;
-using NUnit.Framework;
+using System;
 using StringSearch.Legacy.Collections;
+using Xunit;
 
 namespace UnitTests.Legacy.Collections
 {
-    [TestFixture]
     public class MemoryEfficientComplementBigULongArrayTests
     {
-        [Test]
+        [Fact]
         public void TestConstructor()
         {
             MemoryEfficientComplementBigULongArray a = new MemoryEfficientComplementBigULongArray(12);
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithMaxValue()
         {
             new MemoryEfficientComplementBigULongArray(12, 7);
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithMaxValueAndValues()
         {
             new MemoryEfficientComplementBigULongArray(12, 7, new MemoryEfficientByteAlignedBigULongArray(12, 7));
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithMaxValueAndValuesAndComplements()
         {
             new MemoryEfficientComplementBigULongArray(12, 7, new MemoryEfficientBigULongArray(12, 7), new BigBoolArray(12));
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithNullValuesArray()
         {
 
             Assert.Throws<ArgumentNullException>(() => new MemoryEfficientComplementBigULongArray(100, 5, null));
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithNullComplementsArray()
         {
             Assert.Throws<ArgumentNullException>(
                 () => new MemoryEfficientComplementBigULongArray(100, 5, new MemoryEfficientBigULongArray(100), null));
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithTooSmallValuesArray()
         {
             Assert.Throws<ArgumentException>(
                 () => new MemoryEfficientComplementBigULongArray(100, 5, new MemoryEfficientBigULongArray(99)));
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithTooSMallComplementsArray()
         {
             Assert.Throws<ArgumentException>(
@@ -61,7 +60,7 @@ namespace UnitTests.Legacy.Collections
                         new BigBoolArray(99)));
         }
 
-        [Test]
+        [Fact]
         public void TestReadWrite()
         {
             MemoryEfficientComplementBigULongArray a = new MemoryEfficientComplementBigULongArray(10, 5);
@@ -73,12 +72,12 @@ namespace UnitTests.Legacy.Collections
             a[7] = ~0ul;
             a[8] = ~3ul;
 
-            Assert.AreEqual(5, a[3]);
-            Assert.AreEqual(0, a[9]);
-            Assert.AreEqual(4, a[0]);
-            Assert.AreEqual(~5ul, a[2]);
-            Assert.AreEqual(~0ul, a[7]);
-            Assert.AreEqual(~3ul, a[8]);
+            Assert.Equal(5ul, a[3]);
+            Assert.Equal(0ul, a[9]);
+            Assert.Equal(4ul, a[0]);
+            Assert.Equal(~5ul, a[2]);
+            Assert.Equal(~0ul, a[7]);
+            Assert.Equal(~3ul, a[8]);
         }
     }
 }

--- a/test/UnitTests/Legacy/CompressionTests.cs
+++ b/test/UnitTests/Legacy/CompressionTests.cs
@@ -1,20 +1,21 @@
-﻿using System;
 using System.IO;
+using System.Reflection;
 using System.Text;
-using NUnit.Framework;
 using StringSearch.Legacy;
+using Xunit;
 
 namespace UnitTests.Legacy
 {
-    [TestFixture]
     public class CompressionTests
     {
-#region Four Bit Digit
-        [Test]
+        private static string workingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+        #region Four Bit Digit
+        [Fact]
         public void CompressFile4BitDigit()
         {
             const string str = "1234567890";
-            string filePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "testCompressFile4BitDigit.");
+            string filePath = Path.Combine(workingDirectory, "testCompressFile4BitDigit.");
 
             writeStringFile(filePath + "txt", str);
             Compression.CompressFile4BitDigit(filePath + "txt", filePath + "4bitDigit");
@@ -24,14 +25,14 @@ namespace UnitTests.Legacy
             File.Delete(filePath + ".txt");
             File.Delete(filePath + ".4bitDigit");
 
-            Assert.AreEqual(str, readBack);
+            Assert.Equal(str, readBack);
         }
 
-        [Test]
+        [Fact]
         public void CompressFile4BitDigitOddLength()
         {
             const string str = "12345678905";
-            string filePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "testCompressFile4BitDigitOddLength.");
+            string filePath = Path.Combine(workingDirectory, "testCompressFile4BitDigitOddLength.");
 
             writeStringFile(filePath + "txt", str);
             Compression.CompressFile4BitDigit(filePath + "txt", filePath + "4bitDigit");
@@ -41,7 +42,7 @@ namespace UnitTests.Legacy
             File.Delete(filePath + ".txt");
             File.Delete(filePath + ".4bitDigit");
 
-            Assert.AreEqual(str, readBack);
+            Assert.Equal(str, readBack);
         }
 #endregion
 

--- a/test/UnitTests/Legacy/ForceGcBetweenTests.cs
+++ b/test/UnitTests/Legacy/ForceGcBetweenTests.cs
@@ -1,5 +1,4 @@
 using System;
-using NUnit.Framework;
 
 namespace UnitTests.Legacy
 {
@@ -8,10 +7,9 @@ namespace UnitTests.Legacy
     /// This frees up as much memory as possible for the next test, and also keeps GC runtime variability out of tests
     /// that didn't create the objects being collected.
     /// </summary>
-    public class ForceGcBetweenTests
+    public class ForceGcBetweenTests : IDisposable
     {
-        [TearDown]
-        public void TearDown()
+        public void Dispose()
         {
             GC.Collect();
         }

--- a/test/UnitTests/Legacy/IO/BigMemoryStreamTests.cs
+++ b/test/UnitTests/Legacy/IO/BigMemoryStreamTests.cs
@@ -1,56 +1,55 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using StringSearch.Legacy.IO;
+using Xunit;
 
 namespace UnitTests.Legacy.IO
 {
-    [TestFixture]
     public class BigMemoryStreamTests : ForceGcBetweenTests
     {
-        [Test]
+        [Fact]
         public void TestConstructorNoParams()
         {
             BigMemoryStream stream = new BigMemoryStream();
 
-            Assert.AreEqual(0, stream.Length);
-            Assert.AreEqual(true, stream.CanWrite);
+            Assert.Equal(0, stream.Length);
+            Assert.True(stream.CanWrite);
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithCapacity()
         {
             BigMemoryStream stream = new BigMemoryStream(10);
 
-            Assert.AreEqual(10, stream.Length); //Big difference to MemoryStream => length == capacity
+            Assert.Equal(10, stream.Length); //Big difference to MemoryStream => length == capacity
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorNegCapacity()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new BigMemoryStream(-1));
         }
 
-        [Test]
+        [Fact]
         public void TestConstructorWithBigCapacity()
         {
             long length = 3L * 1024L * 1024L * 1024L; //3GiB
 
             BigMemoryStream stream = new BigMemoryStream(length);
 
-            Assert.AreEqual(length, stream.Length);
+            Assert.Equal(length, stream.Length);
         }
 
-        [Test]
+        [Fact]
         public void TestPositionStart()
         {
             BigMemoryStream stream = new BigMemoryStream();
 
-            Assert.AreEqual(0, stream.Position);
+            Assert.Equal(0, stream.Position);
         }
 
-        [Test]
+        [Fact]
         public void TestSetPosition()
         {
             BigMemoryStream stream = new BigMemoryStream(10);
@@ -59,11 +58,11 @@ namespace UnitTests.Legacy.IO
             {
                 stream.Position = i;
 
-                Assert.AreEqual(i, stream.Position);
+                Assert.Equal(i, stream.Position);
             }
         }
 
-        [Test]
+        [Fact]
         public void TestSetPositionBig()
         {
             long length = 3L * 1024L * 1024L * 1024L; //3GiB
@@ -72,14 +71,14 @@ namespace UnitTests.Legacy.IO
 
             //Small position on big stream
             stream.Position = 10;
-            Assert.AreEqual(10, stream.Position);
+            Assert.Equal(10, stream.Position);
 
             //Big position on big stream
             stream.Position = length - 5;
-            Assert.AreEqual(length - 5, stream.Position);
+            Assert.Equal(length - 5, stream.Position);
         }
 
-        [Test]
+        [Fact]
         public void TestSetPositionNeg()
         {
             BigMemoryStream stream = new BigMemoryStream();
@@ -87,7 +86,7 @@ namespace UnitTests.Legacy.IO
             Assert.Throws<ArgumentOutOfRangeException>(() => stream.Position = -1);
         }
 
-        [Test]
+        [Fact]
         public void TestPositionMovesOnRead()
         {
             BigMemoryStream stream = new BigMemoryStream(100);
@@ -96,10 +95,10 @@ namespace UnitTests.Legacy.IO
             byte[] buffer = new byte[5];
             stream.Read(buffer, 0, 5);
 
-            Assert.AreEqual(10, stream.Position);
+            Assert.Equal(10, stream.Position);
         }
 
-        [Test]
+        [Fact]
         public void TestPositionMovesOnWrite()
         {
             BigMemoryStream stream = new BigMemoryStream(100);
@@ -114,10 +113,10 @@ namespace UnitTests.Legacy.IO
 
             stream.Write(toWrite, 0, toWrite.Length);
 
-            Assert.AreEqual(15, stream.Position);
+            Assert.Equal(15, stream.Position);
         }
 
-        [Test]
+        [Fact]
         public void TestPositionMovesOnReadByte()
         {
             BigMemoryStream stream = new BigMemoryStream(100);
@@ -126,10 +125,10 @@ namespace UnitTests.Legacy.IO
 
             stream.ReadByte();
 
-            Assert.AreEqual(6, stream.Position);
+            Assert.Equal(6, stream.Position);
         }
 
-        [Test]
+        [Fact]
         public void TesPositionMovesOnWriteByte()
         {
             BigMemoryStream stream = new BigMemoryStream(100);
@@ -138,10 +137,10 @@ namespace UnitTests.Legacy.IO
 
             stream.WriteByte(3);
 
-            Assert.AreEqual(6, stream.Position);
+            Assert.Equal(6, stream.Position);
         }
 
-        [Test]
+        [Fact]
         public void TestSetPositionToLength()
         {
             BigMemoryStream stream = new BigMemoryStream(5);
@@ -149,7 +148,7 @@ namespace UnitTests.Legacy.IO
             stream.Position = 5; //Should be fine to set position, but fail on read/write
         }
 
-        [Test]
+        [Fact]
         public void TestReadWrite()
         {
             int length = 100;
@@ -170,10 +169,10 @@ namespace UnitTests.Legacy.IO
             byte[] buffer = new byte[length];
             stream.Read(buffer, 0, length);
 
-            CollectionAssert.AreEqual(values, buffer);
+            Assert.Equal(values, buffer);
         }
 
-        [Test]
+        [Fact]
         public void TestReadWriteBig()
         {
             long length = 3L * 1024L * 1024L * 1024L; //3GiB
@@ -194,10 +193,10 @@ namespace UnitTests.Legacy.IO
             byte[] buffer = new byte[values.Length];
             stream.Read(buffer, 0, values.Length);
 
-            CollectionAssert.AreEqual(values, buffer);
+            Assert.Equal(values, buffer);
         }
 
-        [Test]
+        [Fact]
         public void TestReadWriteBigAboveIntegerIndex()
         {
             long length = 3L * 1024L * 1024L * 1024L; //3GiB
@@ -221,10 +220,10 @@ namespace UnitTests.Legacy.IO
             byte[] buffer = new byte[values.Length];
             stream.Read(buffer, 0, values.Length);
 
-            CollectionAssert.AreEqual(values, buffer);
+            Assert.Equal(values, buffer);
         }
 
-        [Test]
+        [Fact]
         public void TestReadWriteOffset1()
         {
             BigMemoryStream stream = new BigMemoryStream(100);
@@ -240,7 +239,7 @@ namespace UnitTests.Legacy.IO
             stream.Position = 0;
             stream.Read(actual1, 0, 4);
 
-            CollectionAssert.AreEqual(expected, actual1);
+            Assert.Equal(expected, actual1);
 
             //Get the bytes back using an offset on read too
             byte[] actual2 = new byte[values.Length];
@@ -249,11 +248,11 @@ namespace UnitTests.Legacy.IO
 
             for(int i = 3; i < 7; i++)
             {
-                Assert.AreEqual(values[i], actual2[i]);
+                Assert.Equal(values[i], actual2[i]);
             }
         }
 
-        [Test]
+        [Fact]
         public void TestReadWriteOffset2()
         {
             int length = 100;
@@ -279,11 +278,11 @@ namespace UnitTests.Legacy.IO
             byte[] buffer = new byte[length];
             int numRead = stream.Read(buffer, writeFrom, length - writeFrom);
 
-            CollectionAssert.AreEqual(expected, buffer);
-            Assert.AreEqual(length - writeFrom, numRead);
+            Assert.Equal(expected, buffer);
+            Assert.Equal(length - writeFrom, numRead);
         }
 
-        [Test]
+        [Fact]
         public void TestReadBufferNull()
         {
             BigMemoryStream stream = new BigMemoryStream(5);
@@ -292,7 +291,7 @@ namespace UnitTests.Legacy.IO
             Assert.Throws<ArgumentNullException>(() => stream.Read(buffer, 0, 1));
         }
 
-        [Test]
+        [Fact]
         public void TestReadNegOffset()
         {
             BigMemoryStream stream = new BigMemoryStream(5);
@@ -301,7 +300,7 @@ namespace UnitTests.Legacy.IO
             Assert.Throws<ArgumentOutOfRangeException>(() => stream.Read(buffer, -1, 1));
         }
 
-        [Test]
+        [Fact]
         public void TestReadNegCount()
         {
             BigMemoryStream stream = new BigMemoryStream(5);
@@ -310,7 +309,7 @@ namespace UnitTests.Legacy.IO
             Assert.Throws<ArgumentOutOfRangeException>(() => stream.Read(buffer, 1, -1));
         }
 
-        [Test]
+        [Fact]
         public void TestReadBufferTooSmall()
         {
             BigMemoryStream stream = new BigMemoryStream(5);
@@ -319,7 +318,7 @@ namespace UnitTests.Legacy.IO
             Assert.Throws<ArgumentException>(() => stream.Read(buffer, 0, 5));
         }
 
-        [Test]
+        [Fact]
         public void TestReadBufferTooSmallDueToOffset()
         {
             BigMemoryStream stream = new BigMemoryStream(5);
@@ -328,7 +327,7 @@ namespace UnitTests.Legacy.IO
             Assert.Throws<ArgumentException>(() => stream.Read(buffer, 1, 4));
         }
 
-        [Test]
+        [Fact]
         public void TestReadEos()
         {
             BigMemoryStream stream = new BigMemoryStream(5);
@@ -337,10 +336,10 @@ namespace UnitTests.Legacy.IO
             stream.Position = 5;
             int bytesRead = stream.Read(buffer, 0, 1);
 
-            Assert.AreEqual(0, bytesRead);
+            Assert.Equal(0, bytesRead);
         }
 
-        [Test]
+        [Fact]
         public void TestReadLastUnset()
         {
             byte[] expected = new byte[] { 0 };
@@ -353,11 +352,11 @@ namespace UnitTests.Legacy.IO
 
             int bytesRead = stream.Read(buffer, 0, 1);
 
-            Assert.AreEqual(1, bytesRead);
-            CollectionAssert.AreEqual(expected, buffer);
+            Assert.Equal(1, bytesRead);
+            Assert.Equal(expected, buffer);
         }
 
-        [Test]
+        [Fact]
         public void TestReadLastUnsetWithMaxSizeOfUnderlyingStream()
         {
             byte[] expected = new byte[] { 0 };
@@ -370,11 +369,11 @@ namespace UnitTests.Legacy.IO
 
             int bytesRead = stream.Read(buffer, 0, 1);
 
-            Assert.AreEqual(1, bytesRead);
-            CollectionAssert.AreEqual(expected, buffer);
+            Assert.Equal(1, bytesRead);
+            Assert.Equal(expected, buffer);
         }
 
-        [Test]
+        [Fact]
         public void TestReadWriteByte()
         {
             BigMemoryStream stream = new BigMemoryStream(100);
@@ -383,10 +382,10 @@ namespace UnitTests.Legacy.IO
 
             stream.Position = 0;
 
-            Assert.AreEqual(5, stream.ReadByte());
+            Assert.Equal(5, stream.ReadByte());
         }
 
-        [Test]
+        [Fact]
         public void TestReadByteEos()
         {
             BigMemoryStream stream = new BigMemoryStream(100);
@@ -394,10 +393,10 @@ namespace UnitTests.Legacy.IO
             stream.Position = 100;
             int b = stream.ReadByte();
 
-            Assert.AreEqual(-1, b);
+            Assert.Equal(-1, b);
         }
 
-        [Test]
+        [Fact]
         public void TestReadByteEosBig()
         {
             long length = 3L * 1024L * 1024L * 1024L; //3GiB
@@ -406,10 +405,10 @@ namespace UnitTests.Legacy.IO
             stream.Position = length;
             int b = stream.ReadByte();
 
-            Assert.AreEqual(-1, b);
+            Assert.Equal(-1, b);
         }
 
-        [Test]
+        [Fact]
         public void TestReadWriteLastByte()
         {
             BigMemoryStream stream = new BigMemoryStream(100);
@@ -419,10 +418,10 @@ namespace UnitTests.Legacy.IO
 
             stream.Position = 99;
             int b = stream.ReadByte();
-            Assert.AreEqual(5, b);
+            Assert.Equal(5, b);
         }
 
-        [Test]
+        [Fact]
         public void TestReadWriteLastByteBig()
         {
             long length = 3L * 1024L * 1024L * 1024L; //3GiB
@@ -433,10 +432,10 @@ namespace UnitTests.Legacy.IO
 
             stream.Position = length - 1;
             int b = stream.ReadByte();
-            Assert.AreEqual(5, b);
+            Assert.Equal(5, b);
         }
 
-        [Test]
+        [Fact]
         public void TestReadWriteLastByteInUnderlyingStream()
         {
             long length = BigMemoryStream.MEMORY_STREAM_MAX_SIZE + 5;
@@ -447,10 +446,10 @@ namespace UnitTests.Legacy.IO
 
             stream.Position = BigMemoryStream.MEMORY_STREAM_MAX_SIZE - 1;
             int b = stream.ReadByte();
-            Assert.AreEqual(5, b);
+            Assert.Equal(5, b);
         }
 
-        [Test]
+        [Fact]
         public void TestReadWriteFirstByteInSecondUnderlyingStream()
         {
             long length = BigMemoryStream.MEMORY_STREAM_MAX_SIZE + 5;
@@ -461,10 +460,10 @@ namespace UnitTests.Legacy.IO
 
             stream.Position = BigMemoryStream.MEMORY_STREAM_MAX_SIZE;
             int b = stream.ReadByte();
-            Assert.AreEqual(5, b);
+            Assert.Equal(5, b);
         }
 
-        [Test]
+        [Fact]
         public void TestReadWriteLastByteInStreamAtMaxOfUnderlyingStream()
         {
             BigMemoryStream stream = new BigMemoryStream(BigMemoryStream.MEMORY_STREAM_MAX_SIZE);
@@ -474,30 +473,30 @@ namespace UnitTests.Legacy.IO
 
             stream.Position = BigMemoryStream.MEMORY_STREAM_MAX_SIZE - 1;
             int b = stream.ReadByte();
-            Assert.AreEqual(5, b);
+            Assert.Equal(5, b);
         }
 
-        [Test]
+        [Fact]
         public void TestReadByteUnset()
         {
             BigMemoryStream stream = new BigMemoryStream(100);
             stream.Position = 50;
 
             int b = stream.ReadByte();
-            Assert.AreEqual(0, b);
+            Assert.Equal(0, b);
         }
 
-        [Test]
+        [Fact]
         public void TestReadLastByteUnset()
         {
             BigMemoryStream stream = new BigMemoryStream(100);
             stream.Position = stream.Length - 1;
 
             int b = stream.ReadByte();
-            Assert.AreEqual(0, b);
+            Assert.Equal(0, b);
         }
 
-        [Test]
+        [Fact]
         public void TestReadLastByteUnsetBig()
         {
             long length = 3L * 1024L * 1024L * 1024L; //3GiB
@@ -505,10 +504,10 @@ namespace UnitTests.Legacy.IO
             stream.Position = stream.Length - 1;
 
             int b = stream.ReadByte();
-            Assert.AreEqual(0, b);
+            Assert.Equal(0, b);
         }
 
-        [Test]
+        [Fact]
         public void TestReadLastByteUnsetWithMaxSizeOfUnderlyingStream()
         {
             BigMemoryStream stream = new BigMemoryStream(BigMemoryStream.MEMORY_STREAM_MAX_SIZE);
@@ -516,10 +515,10 @@ namespace UnitTests.Legacy.IO
             stream.Position = stream.Length - 1;
 
             int b = stream.ReadByte();
-            Assert.AreEqual(0, b);
+            Assert.Equal(0, b);
         }
 
-        [Test]
+        [Fact]
         public void TestDisposed()
         {
             BigMemoryStream stream = new BigMemoryStream(5);

--- a/test/UnitTests/Legacy/SearchStringTests.cs
+++ b/test/UnitTests/Legacy/SearchStringTests.cs
@@ -1,101 +1,100 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using NUnit.Framework;
 using StringSearch.Legacy;
 using StringSearch.Legacy.Collections;
 using SuffixArray;
 using UnitTests.TestObjects.Extensions;
+using Xunit;
 
 namespace UnitTests.Legacy
 {
-    [TestFixture]
     public class SearchStringTests
     {
         #region Search(string, string)
-        [Test]
+        [Fact]
         public void SequentialSearch()
         {
             const string str = "123456789991234";
 
-            Dictionary<string, int[]> answers = new Dictionary<string, int[]>()
+            Dictionary<string, long[]> answers = new Dictionary<string, long[]>()
             {
-                { "1", new int[] { 0, 11 } },
-                { "2", new int[] { 1, 12 } },
-                { "12", new int[] { 0, 11 } },
-                { "5", new int[] { 4 } }
+                { "1", new long[] { 0, 11 } },
+                { "2", new long[] { 1, 12 } },
+                { "12", new long[] { 0, 11 } },
+                { "5", new long[] { 4 } }
             };
 
-            foreach(KeyValuePair<string, int[]> kvp in answers)
+            foreach(KeyValuePair<string, long[]> kvp in answers)
             {
                 string find = kvp.Key;
-                int[] expected = kvp.Value;
+                long[] expected = kvp.Value;
 
-                int[] actual = SearchString.Search(str, find);
+                long[] actual = SearchString.Search(str, find);
 
-                CollectionAssert.AreEqual(expected, actual);
+                Assert.Equal(expected, actual);
             }
         }
 
-        [Test]
+        [Fact]
         public void SequentialSearchLastValue()
         {
             const string str = "123456789991234";
 
-            Dictionary<string, int[]> answers = new Dictionary<string, int[]>()
+            Dictionary<string, long[]> answers = new Dictionary<string, long[]>()
             {
-                { "4", new int[] { 3, 14 } }
+                { "4", new long[] { 3, 14 } }
             };
 
-            foreach (KeyValuePair<string, int[]> kvp in answers)
+            foreach (KeyValuePair<string, long[]> kvp in answers)
             {
                 string find = kvp.Key;
-                int[] expected = kvp.Value;
+                long[] expected = kvp.Value;
 
-                int[] actual = SearchString.Search(str, find);
+                long[] actual = SearchString.Search(str, find);
 
-                CollectionAssert.AreEqual(expected, actual);
+                Assert.Equal(expected, actual);
             }
         }
 
-        [Test]
+        [Fact]
         public void SequentialSearchFullString()
         {
             const string str = "123456789991234";
 
-            int[] expected = new int[] { 0 };
+            long[] expected = new long[] { 0 };
 
-            int[] actual = SearchString.Search(str, str);
+            long[] actual = SearchString.Search(str, str);
 
-            CollectionAssert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        [Test]
+        [Fact]
         public void SequentialSearchLookForLongerThanToSearch()
         {
             const string str = "123456789991234";
             const string find = str + "7";
 
-            int[] expected = new int[0];
+            long[] expected = new long[0];
 
-            int[] actual = SearchString.Search(str, find);
+            long[] actual = SearchString.Search(str, find);
 
-            CollectionAssert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        [Test]
+        [Fact]
         public void SequentialSearchSearchNull()
         {
             Assert.Throws<ArgumentNullException>(() => SearchString.Search(null, "1"));
         }
 
-        [Test]
+        [Fact]
         public void SequentialSearchLookForNull()
         {
             Assert.Throws<ArgumentNullException>(() => SearchString.Search("123", null));
         }
 
-        [Test]
+        [Fact]
         public void SequentialSearchLookForEmptyString()
         {
             const string str = "123456789991234";
@@ -104,22 +103,22 @@ namespace UnitTests.Legacy
             Assert.Throws<ArgumentException>(() => SearchString.Search(str, find));
         }
 
-        [Test]
+        [Fact]
         public void SequentialSearchSearchEmptyString()
         {
             const string str = "";
             const string find = "1";
 
-            int[] expected = new int[0];
+            long[] expected = new long[0];
 
-            int[] actual = SearchString.Search(str, find);
+            long[] actual = SearchString.Search(str, find);
 
-            CollectionAssert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
         #endregion
 
         #region Search(int[], FourBitDigitBigArray, string)
-        [Test]
+        [Fact]
         public void SearchSuffixArray()
         {
             const string str = "123456789";
@@ -133,16 +132,16 @@ namespace UnitTests.Legacy
                 {
                     string find = str.Substring(i, j - i);
 
-                    int[] seqSearchRes = SearchString.Search(str, find);
+                    long[] seqSearchRes = SearchString.Search(str, find);
                     SuffixArrayRange suffixArrayRange = SearchString.Search(suffixArray, fourBitDigitArray, find);
                     long[] suffixArraySearchRes = suffixArrayRange.SortedValues;
 
-                    CollectionAssert.AreEqual(seqSearchRes, suffixArraySearchRes);
+                    Assert.Equal(seqSearchRes, suffixArraySearchRes);
                 }
             }
         }
 
-        [Test]
+        [Fact]
         public void SearchSuffixArrayManualTest()
         {
             const string str = "1234567899912340";
@@ -166,11 +165,11 @@ namespace UnitTests.Legacy
                 SuffixArrayRange suffixArrayRange = SearchString.Search(suffixArray, fourBitDigitArray, find);
                 long[] actual = suffixArrayRange.SortedValues;
 
-                CollectionAssert.AreEqual(expected, actual);
+                Assert.Equal(expected, actual);
             }
         }
 
-        [Test]
+        [Fact]
         public void SearchSuffixArrayLastDigits()
         {
             const string str = "1234567899912340";
@@ -185,10 +184,10 @@ namespace UnitTests.Legacy
             SuffixArrayRange suffixArrayRange = SearchString.Search(suffixArray, fourBitDigitArray, find);
             long[] actual = suffixArrayRange.SortedValues;
 
-            CollectionAssert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        [Test]
+        [Fact]
         public void SearchSuffixArrayFirstDigits()
         {
             const string str = "1234567899912340";
@@ -203,10 +202,10 @@ namespace UnitTests.Legacy
             SuffixArrayRange suffixArrayRange = SearchString.Search(suffixArray, fourBitDigitArray, find);
             long[] actual = suffixArrayRange.SortedValues;
 
-            CollectionAssert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        [Test]
+        [Fact]
         public void SearchSuffixArrayAllDigits()
         {
             const string str = "1234567899912340";
@@ -219,10 +218,10 @@ namespace UnitTests.Legacy
             SuffixArrayRange suffixArrayRange = SearchString.Search(suffixArray, fourBitDigitArray, str);
             long[] actual = suffixArrayRange.SortedValues;
 
-            CollectionAssert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        [Test]
+        [Fact]
         public void SearchSuffixArrayForEmptyString()
         {
             const string str = "123456789";
@@ -233,7 +232,7 @@ namespace UnitTests.Legacy
             Assert.Throws<ArgumentException>(() => SearchString.Search(suffixArray, fourBitDigitArray, ""));
         }
 
-        [Test]
+        [Fact]
         public void SearchSuffixArraySearchEmptyString()
         {
             const string str = "";
@@ -247,10 +246,10 @@ namespace UnitTests.Legacy
             SuffixArrayRange suffixArrayRange = SearchString.Search(suffixArray, fourBitDigitArray, find);
             long[] actual = suffixArrayRange.SortedValues;
 
-            CollectionAssert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        [Test]
+        [Fact]
         public void TestSuffixArrayWrongSize()
         {
             IBigArray<ulong> suffixArray = new int[] { 1, 2, 3 }.ToBigULongArray();
@@ -259,7 +258,7 @@ namespace UnitTests.Legacy
             Assert.Throws<ArgumentException>(() => SearchString.Search(suffixArray, a, "23"));
         }
 
-        [Test]
+        [Fact]
         public void TestSuffixArraySearchDigitNotInString()
         {
             const string str = "1234567912340";
@@ -273,13 +272,13 @@ namespace UnitTests.Legacy
             SuffixArrayRange suffixArrayRange = SearchString.Search(suffixArray, fourBitDigitArray, find);
             long[] actual = suffixArrayRange.SortedValues;
 
-            Assert.AreEqual(false, suffixArrayRange.HasResults);
-            CollectionAssert.AreEqual(expected, actual);
+            Assert.False(suffixArrayRange.HasResults);
+            Assert.Equal(expected, actual);
         }
         #endregion
 
         #region FindNextOccurrence(string, string, int)
-        [Test]
+        [Fact]
         public void TestFindNextOccurrence()
         {
             const string str = "123456789991234";
@@ -300,52 +299,52 @@ namespace UnitTests.Legacy
 
                 int actual = SearchString.FindNextOccurrence(str, find, fromIdx);
 
-                Assert.AreEqual(expected, actual);
+                Assert.Equal(expected, actual);
             }
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrenceLastDigits()
         {
             const string str = "123456789991234";
 
-            Assert.AreEqual(10, SearchString.FindNextOccurrence(str, "91234", 0));
+            Assert.Equal(10, SearchString.FindNextOccurrence(str, "91234", 0));
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrenceSearchFullString()
         {
             const string str = "123456789991234";
 
-            Assert.AreEqual(0, SearchString.FindNextOccurrence(str, str, 0));
+            Assert.Equal(0, SearchString.FindNextOccurrence(str, str, 0));
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrenceLookForLongerThanToSearch()
         {
             const string str = "123456789991234";
 
-            Assert.AreEqual(-1, SearchString.FindNextOccurrence(str, str + "1", 0));
+            Assert.Equal(-1, SearchString.FindNextOccurrence(str, str + "1", 0));
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrenceLookForLongerThanLeftInToSearch()
         {
             const string str = "123456789991234";
 
-            Assert.AreEqual(-1, SearchString.FindNextOccurrence(str, "43", str.Length - 1));
+            Assert.Equal(-1, SearchString.FindNextOccurrence(str, "43", str.Length - 1));
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrenceSearchLastDigit()
         {
             const string str = "123456789991234";
 
-            Assert.AreEqual(str.Length - 1, SearchString.FindNextOccurrence(str, str[str.Length - 1].ToString(), str.Length - 1));
-            Assert.AreEqual(-1, SearchString.FindNextOccurrence(str, "5", str.Length - 1));
+            Assert.Equal(str.Length - 1, SearchString.FindNextOccurrence(str, str[str.Length - 1].ToString(), str.Length - 1));
+            Assert.Equal(-1, SearchString.FindNextOccurrence(str, "5", str.Length - 1));
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrenceLookForEmptyString()
         {
             const string str = "123456789991234";
@@ -354,7 +353,7 @@ namespace UnitTests.Legacy
             Assert.Throws<ArgumentException>(() => SearchString.FindNextOccurrence(str, "", 0));
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrenceSearchEmptyString()
         {
             Assert.Throws<ArgumentException>(() => SearchString.FindNextOccurrence("", "1", 0));
@@ -362,7 +361,7 @@ namespace UnitTests.Legacy
         #endregion
 
         #region FindNextOccurrence4BitDigit(Stream, string int)
-        [Test]
+        [Fact]
         public void TestFindNextOccurrence4BitDigit()
         {
             const string str = "123456789991234";
@@ -384,57 +383,57 @@ namespace UnitTests.Legacy
 
                 long actual = SearchString.FindNextOccurrence4BitDigit(s, find, fromIdx);
 
-                Assert.AreEqual(expected, actual);
+                Assert.Equal(expected, actual);
             }
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrence4BitDigitLastDigits()
         {
             const string str = "123456789991234";
             Stream s = str.ToFourBitDigitStream();
 
-            Assert.AreEqual(10, SearchString.FindNextOccurrence4BitDigit(s, "91234", 0));
+            Assert.Equal(10, SearchString.FindNextOccurrence4BitDigit(s, "91234", 0));
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrence4BitDigitSearchFullString()
         {
             const string str = "123456789991234";
             Stream s = str.ToFourBitDigitStream();
 
-            Assert.AreEqual(0, SearchString.FindNextOccurrence4BitDigit(s, str, 0));
+            Assert.Equal(0, SearchString.FindNextOccurrence4BitDigit(s, str, 0));
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrence4BitDigitLookForLongerThanToSearch()
         {
             const string str = "123456789991234";
             Stream s = str.ToFourBitDigitStream();
 
-            Assert.AreEqual(-1, SearchString.FindNextOccurrence4BitDigit(s, str + "1", 0));
+            Assert.Equal(-1, SearchString.FindNextOccurrence4BitDigit(s, str + "1", 0));
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrence4BitDigitLookForLongerThanLeftInToSearch()
         {
             const string str = "123456789991234";
             Stream s = str.ToFourBitDigitStream();
 
-            Assert.AreEqual(-1, SearchString.FindNextOccurrence4BitDigit(s, "43", str.Length - 1));
+            Assert.Equal(-1, SearchString.FindNextOccurrence4BitDigit(s, "43", str.Length - 1));
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrence4BitDigitSearchLastDigit()
         {
             const string str = "123456789991234";
             Stream s = str.ToFourBitDigitStream();
 
-            Assert.AreEqual(str.Length - 1, SearchString.FindNextOccurrence4BitDigit(s, str[str.Length - 1].ToString(), str.Length - 1));
-            Assert.AreEqual(-1, SearchString.FindNextOccurrence4BitDigit(s, "5", str.Length - 1));
+            Assert.Equal(str.Length - 1, SearchString.FindNextOccurrence4BitDigit(s, str[str.Length - 1].ToString(), str.Length - 1));
+            Assert.Equal(-1, SearchString.FindNextOccurrence4BitDigit(s, "5", str.Length - 1));
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrence4BitDigitLookForEmptyString()
         {
             const string str = "123456789991234";
@@ -443,7 +442,7 @@ namespace UnitTests.Legacy
             Assert.Throws<ArgumentException>(() => SearchString.FindNextOccurrence4BitDigit(s, "", 0));
         }
 
-        [Test]
+        [Fact]
         public void TestFindNextOccurrence4BitDigitSearchEmptyString()
         {
             Stream s = "".ToFourBitDigitStream();
@@ -453,7 +452,7 @@ namespace UnitTests.Legacy
         #endregion
 
         #region Internals
-        [Test]
+        [Fact]
         public void TestDoesStartWithSuffix()
         {
             const string str = "12345678901234";
@@ -469,12 +468,12 @@ namespace UnitTests.Legacy
                     string strFind = str.Substring(i, j - i);
                     byte[] find = stringToByteArr(strFind);
 
-                    Assert.AreEqual(0, SearchString.DoesStartWithSuffix(fourBitDigitArray, find, i));
+                    Assert.Equal(0, SearchString.DoesStartWithSuffix(fourBitDigitArray, find, i));
                 }
             }
         }
 
-        [Test]
+        [Fact]
         public void TestDoesStartWithSuffixTooLow()
         {
             const string str = "12345678901234";
@@ -484,10 +483,10 @@ namespace UnitTests.Legacy
             string strToFind = "0" + str.Substring(1);
             byte[] toFind = stringToByteArr(strToFind);
 
-            Assert.AreEqual(1, SearchString.DoesStartWithSuffix(fourBitDigitArray, toFind, 0));
+            Assert.Equal(1, SearchString.DoesStartWithSuffix(fourBitDigitArray, toFind, 0));
         }
 
-        [Test]
+        [Fact]
         public void TestDoesStartWithSuffixTooHigh()
         {
             const string str = "12345678901234";
@@ -497,10 +496,10 @@ namespace UnitTests.Legacy
             string strToFind = "2" + str.Substring(1);
             byte[] toFind = stringToByteArr(strToFind);
 
-            Assert.AreEqual(-1, SearchString.DoesStartWithSuffix(fourBitDigitArray, toFind, 0));
+            Assert.Equal(-1, SearchString.DoesStartWithSuffix(fourBitDigitArray, toFind, 0));
         }
 
-        [Test]
+        [Fact]
         public void TestDoesStartWithSuffixDigitArrayTooSmallMatchUntilEnd()
         {
             const string str = "1234567890";
@@ -510,10 +509,10 @@ namespace UnitTests.Legacy
             string strToFind = "901";
             byte[] toFind = stringToByteArr(strToFind);
 
-            Assert.AreEqual(-1, SearchString.DoesStartWithSuffix(fourBitDigitArray, toFind, str.Length - 2));
+            Assert.Equal(-1, SearchString.DoesStartWithSuffix(fourBitDigitArray, toFind, str.Length - 2));
         }
 
-        [Test]
+        [Fact]
         public void TestDoesStartWithSuffixLastDigitsInDigitArray()
         {
             const string str = "1234567890";
@@ -523,10 +522,10 @@ namespace UnitTests.Legacy
             string strToFind = "90";
             byte[] toFind = stringToByteArr(strToFind);
 
-            Assert.AreEqual(0, SearchString.DoesStartWithSuffix(fourBitDigitArray, toFind, str.Length - 2));
+            Assert.Equal(0, SearchString.DoesStartWithSuffix(fourBitDigitArray, toFind, str.Length - 2));
         }
 
-        [Test]
+        [Fact]
         public void TestDoesStartWithSuffixDigitArrayDigitArrayTooSmallNotMatchUntilEnd()
         {
             const string str = "1234567890";
@@ -536,15 +535,15 @@ namespace UnitTests.Legacy
             string strToFindHigh = "911";
             byte[] toFindHigh = stringToByteArr(strToFindHigh);
 
-            Assert.AreEqual(-1, SearchString.DoesStartWithSuffix(fourBitDigitArray, toFindHigh, str.Length - 2));
+            Assert.Equal(-1, SearchString.DoesStartWithSuffix(fourBitDigitArray, toFindHigh, str.Length - 2));
 
             string strToFindLow = "871";
             byte[] toFindLow = stringToByteArr(strToFindLow);
 
-            Assert.AreEqual(1, SearchString.DoesStartWithSuffix(fourBitDigitArray, toFindLow, str.Length - 2));
+            Assert.Equal(1, SearchString.DoesStartWithSuffix(fourBitDigitArray, toFindLow, str.Length - 2));
         }
 
-        [Test]
+        [Fact]
         public void TestBinarySearchForPrefixSingleChars()
         {
             const string str = "2734981324";
@@ -558,11 +557,11 @@ namespace UnitTests.Legacy
 
                 long answer = SearchString.BinarySearchForPrefix(suffixArray, fourBitDigitArray, find, 0, str.Length - 1);
 
-                Assert.AreEqual(fourBitDigitArray[i], fourBitDigitArray[(long)suffixArray[answer]]);
+                Assert.Equal(fourBitDigitArray[i], fourBitDigitArray[(long)suffixArray[answer]]);
             }
         }
 
-        [Test]
+        [Fact]
         public void TestBinarySearchForPrefixDoNotExist()
         {
             const string str = "8651287431284472619471";
@@ -577,7 +576,7 @@ namespace UnitTests.Legacy
 
                 long answer = SearchString.BinarySearchForPrefix(suffixArray, fourBitDigitArray, find, 0, fourBitDigitArray.Length - 1);
 
-                Assert.AreEqual(-1, answer);
+                Assert.Equal(-1, answer);
             }
         }
         #endregion

--- a/test/UnitTests/Makefile
+++ b/test/UnitTests/Makefile
@@ -5,7 +5,7 @@
 run:
 # If not on windows, set a filter to exclude the windows-specific tests
 ifeq ($(shell uname), Linux)
-	$(eval testFilter = --filter TestCategory!=windows)
+	$(eval testFilter = --filter os!=windows)
 endif
 
 	dotnet test \

--- a/test/UnitTests/Properties/AssemblyInfo.cs
+++ b/test/UnitTests/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/test/UnitTests/TestObjects/Extensions/IntArrayToBigArrayUlongExtensions.cs
+++ b/test/UnitTests/TestObjects/Extensions/IntArrayToBigArrayUlongExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using StringSearch.Legacy.Collections;
+﻿using StringSearch.Legacy.Collections;
 
 namespace UnitTests.TestObjects.Extensions
 {

--- a/test/UnitTests/TestObjects/Extensions/StringToFourBitDigitArrayExtensions.cs
+++ b/test/UnitTests/TestObjects/Extensions/StringToFourBitDigitArrayExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+﻿using System.IO;
 using StringSearch.Legacy.Collections;
 
 namespace UnitTests.TestObjects.Extensions

--- a/test/UnitTests/TestObjects/Extensions/StringToStreamExtensions.cs
+++ b/test/UnitTests/TestObjects/Extensions/StringToStreamExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using StringSearch;
+﻿using System.IO;
 using StringSearch.Legacy;
 
 namespace UnitTests.TestObjects.Extensions

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -8,8 +8,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Nunit 4 had been released, which would require rework to upgrade. Since I'd pick xunit if writing this now, I decided to just port the tests to xunit instead of nunit4.